### PR TITLE
Avoid NA output if there are duplicate rownames.

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -2,12 +2,12 @@
   ff <- function(y,x) {
     xx <- x[(y>0)&(y<=quantile(y,probs=0.99))]
     yy <- log(y[(y>0)&(y<=quantile(y,probs=0.99))])
-    
+
     l <- loess(yy~xx)
     y.fit <- predict(l,newdata=x)
     names(y.fit) <- names(y)
     y.fit[is.na(y.fit)] <- 0
-  
+
     retval <- y/exp(y.fit-median(yy))
     return(retval)
   }
@@ -23,6 +23,14 @@
     if(is.null(names(y))) {
       names(y) <- 1:length(y)
     }
+    # take care of duplicate rownames
+    if(any(duplicated(names(y)))){
+      dups <- TRUE
+      originalNames <- names(y)
+      names(y) <- 1:length(y)
+    } else {
+      dups <- FALSE
+    }
     tmp <- tapply(y,bins,function(x) x)
     switch(which,
            full = {y.norm <- normalizeQuantileRank(tmp)},
@@ -32,9 +40,8 @@
     names <- unlist(sapply(y.norm,names))
     y.norm <- unlist(y.norm)
     names(y.norm) <- names
-    if(!any(duplicated(names(y)))){
-      y.norm[names(y)]
-    }
+    y.norm <- y.norm[names(y)]
+    if(dups) names(y.norm) <- originalNames[as.numeric(names(y.norm))]
     return(y.norm)
     }
   apply(counts,2,f)

--- a/R/functions.R
+++ b/R/functions.R
@@ -32,7 +32,9 @@
     names <- unlist(sapply(y.norm,names))
     y.norm <- unlist(y.norm)
     names(y.norm) <- names
-    y.norm[names(y)]
-  }
+    if(!any(duplicated(names(y)))){
+      y.norm[names(y)]
+    }
+    }
   apply(counts,2,f)
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -35,6 +35,7 @@
     if(!any(duplicated(names(y)))){
       y.norm[names(y)]
     }
+    return(y.norm)
     }
   apply(counts,2,f)
 }

--- a/tests/testthat/test_ordering.R
+++ b/tests/testthat/test_ordering.R
@@ -1,0 +1,17 @@
+context("Test same ordering of rows after normalization if no rownames.")
+
+counts <- matrix(rnbinom(n=1e3, size=2,
+                         mu=rnorm(n=1e3, mean=100, sd=10)),
+                 nrow=100, ncol=10)
+gc <- runif(n=100, min=0.3, max=0.8)
+
+test_that("ordering is correct without rownames", {
+  # normalize a matrix without rownames (and strip any name given by the function)
+  normCounts_noNames <- unname(withinLaneNormalization(unname(counts), gc, which="full"))
+  # normalize a matrix with rownames (and strip any name given by the function)
+  rownames(counts) <- paste0("gene", 1:nrow(counts))
+  normCounts_withNames <- unname(withinLaneNormalization(counts, gc, which="full"))
+
+  expect_equal(normCounts_noNames, normCounts_withNames)
+}
+)


### PR DESCRIPTION
If there are duplicates in the rownames of the count matrix, the full quantile normalization returns `NA` values for all counts of the features corresponding to the duplicate rownames.
This PR avoids this by only resetting the rownames if there are no duplicates.